### PR TITLE
Add key to inner span of a label

### DIFF
--- a/dist/react_monad/html.js
+++ b/dist/react_monad/html.js
@@ -42,7 +42,7 @@ var Label = (function (_super) {
     };
     Label.prototype.render = function () {
         var content = this.state.p == "creating" ? null : this.state.p;
-        var span = React.createElement("span", null, this.props.text);
+        var span = React.createElement("span", { key: "label_span" }, this.props.text);
         return React.createElement("label", { className: this.props.className }, this.props.span_before_content ? [span, content] : [content, span]);
     };
     return Label;

--- a/src/react_monad/html.tsx
+++ b/src/react_monad/html.tsx
@@ -36,7 +36,7 @@ class Label<A,B> extends React.Component<LabelProps<A,B>,LabelState<A,B>> {
 
   render() {
     let content : JSX.Element = this.state.p == "creating" ? null : this.state.p
-    let span = <span>{this.props.text}</span>
+    let span = <span key="label_span">{this.props.text}</span>
     return <label className={this.props.className}>
              {this.props.span_before_content ? [span,content] : [content,span]}
            </label>


### PR DESCRIPTION
This PR adds a `key` attribute to the inner span of a `Label` component. This prevents unique/ duplicate key warnings